### PR TITLE
Improve room-aware validation for all dimensions and openings

### DIFF
--- a/roomsizer/cli.py
+++ b/roomsizer/cli.py
@@ -432,11 +432,12 @@ def get_openings(
         while True:
             try:
                 # Use room-aware dimension reading with priority checks
-                max_wall_dimension = max(room.width, room.length)
+                # Use minimum wall dimension to ensure opening fits on smallest wall
+                min_wall_dimension = min(room.width, room.length)
                 width = read_opening_dimension(
                     "  Width (m): ",
                     "window width",
-                    room_limit=max_wall_dimension,
+                    room_limit=min_wall_dimension,
                     room_dimension_name="room width",
                     min_value=MIN_WINDOW_WIDTH,
                     max_value=MAX_WINDOW_WIDTH,
@@ -478,11 +479,12 @@ def get_openings(
         while True:
             try:
                 # Use room-aware dimension reading with priority checks
-                max_wall_dimension = max(room.width, room.length)
+                # Use minimum wall dimension to ensure opening fits on smallest wall
+                min_wall_dimension = min(room.width, room.length)
                 width = read_opening_dimension(
                     "  Width (m): ",
                     "door width",
-                    room_limit=max_wall_dimension,
+                    room_limit=min_wall_dimension,
                     room_dimension_name="room width",
                     min_value=MIN_DOOR_WIDTH,
                     max_value=MAX_DOOR_WIDTH,

--- a/roomsizer/cli.py
+++ b/roomsizer/cli.py
@@ -25,7 +25,25 @@ from roomsizer.logging_conf import configure_logging
 logger = logging.getLogger(__name__)
 
 # Sanity limits for dimensions (to catch typos)
-MAX_DIMENSION = 100.0  # meters
+# Room dimensions
+MIN_ROOM_WIDTH = 1.5  # meters
+MAX_ROOM_WIDTH = 100.0  # meters
+MIN_ROOM_LENGTH = 1.5  # meters
+MAX_ROOM_LENGTH = 100.0  # meters
+MIN_ROOM_HEIGHT = 2.0  # meters
+MAX_ROOM_HEIGHT = 3.0  # meters
+
+# Opening dimensions
+MIN_WINDOW_WIDTH = 0.3  # meters
+MAX_WINDOW_WIDTH = 5.0  # meters
+MIN_WINDOW_HEIGHT = 0.3  # meters
+MAX_WINDOW_HEIGHT = 3.0  # meters
+MIN_DOOR_WIDTH = 0.6  # meters
+MAX_DOOR_WIDTH = 3.0  # meters
+MIN_DOOR_HEIGHT = 1.8  # meters
+MAX_DOOR_HEIGHT = 3.0  # meters
+
+# Wallpaper roll limits
 MAX_ROLL_LENGTH = 50.0  # meters
 
 
@@ -38,6 +56,7 @@ def read_positive_float(
     prompt: str,
     field_name: str = "value",
     allow_zero: bool = False,
+    min_value: float | None = None,
     max_value: float | None = None,
     input_func: Callable[[str], str] = input,
     output_func: Callable[..., None] = print,
@@ -48,7 +67,8 @@ def read_positive_float(
         prompt: The prompt to display to the user.
         field_name: Name of the field for error messages.
         allow_zero: Whether to allow zero as a valid value.
-        max_value: Maximum allowed value (for sanity checking).
+        min_value: Minimum expected value (for sanity checking).
+        max_value: Maximum expected value (for sanity checking).
         input_func: Function to read input (default: input).
         output_func: Function to write output (default: print).
 
@@ -58,9 +78,15 @@ def read_positive_float(
     Raises:
         UserCancelled: If the user interrupts input.
     """
+    last_out_of_bounds_value: float | None = None
+
     while True:
         try:
-            value = float(input_func(prompt).strip())
+            raw_input = input_func(prompt).strip()
+            # Support both comma and dot as decimal separator
+            normalized_input = raw_input.replace(',', '.')
+            value = float(normalized_input)
+
             if allow_zero and value == 0:
                 return value
             if value <= 0:
@@ -69,17 +95,44 @@ def read_positive_float(
                     file=sys.stderr
                 )
                 continue
+
+            # Check minimum bounds
+            if min_value is not None and value < min_value:
+                # If user entered the same out-of-bounds value again, accept it as confirmed
+                if last_out_of_bounds_value is not None and abs(value - last_out_of_bounds_value) < 0.001:
+                    return value
+
+                last_out_of_bounds_value = value
+                output_func(
+                    f"Warning: {field_name} ({value:.2f}) seems unusually small. "
+                    f"Minimum expected: {min_value:.2f}",
+                    file=sys.stderr
+                )
+                output_func(
+                    "Please re-enter if this was a typo, or enter the same value again to confirm.",
+                    file=sys.stderr
+                )
+                continue
+
+            # Check maximum bounds
             if max_value is not None and value > max_value:
+                # If user entered the same out-of-bounds value again, accept it as confirmed
+                if last_out_of_bounds_value is not None and abs(value - last_out_of_bounds_value) < 0.001:
+                    return value
+
+                last_out_of_bounds_value = value
                 output_func(
                     f"Warning: {field_name} ({value:.2f}) seems unusually large. "
                     f"Maximum expected: {max_value:.2f}",
                     file=sys.stderr
                 )
                 output_func(
-                    "Please re-enter if this was a typo, or continue if correct.",
+                    "Please re-enter if this was a typo, or enter the same value again to confirm.",
                     file=sys.stderr
                 )
                 continue
+
+            # Value is within bounds, accept it
             return value
         except ValueError:
             output_func(
@@ -203,21 +256,24 @@ def get_room_dimensions(
             width = read_positive_float(
                 "Room width (m): ",
                 "room width",
-                max_value=MAX_DIMENSION,
+                min_value=MIN_ROOM_WIDTH,
+                max_value=MAX_ROOM_WIDTH,
                 input_func=input_func,
                 output_func=output_func,
             )
             length = read_positive_float(
                 "Room length (m): ",
                 "room length",
-                max_value=MAX_DIMENSION,
+                min_value=MIN_ROOM_LENGTH,
+                max_value=MAX_ROOM_LENGTH,
                 input_func=input_func,
                 output_func=output_func,
             )
             height = read_positive_float(
                 "Room height (m): ",
                 "room height",
-                max_value=MAX_DIMENSION,
+                min_value=MIN_ROOM_HEIGHT,
+                max_value=MAX_ROOM_HEIGHT,
                 input_func=input_func,
                 output_func=output_func,
             )
@@ -274,14 +330,16 @@ def get_openings(
                 width = read_positive_float(
                     "  Width (m): ",
                     "window width",
-                    max_value=MAX_DIMENSION,
+                    min_value=MIN_WINDOW_WIDTH,
+                    max_value=MAX_WINDOW_WIDTH,
                     input_func=input_func,
                     output_func=output_func,
                 )
                 height = read_positive_float(
                     "  Height (m): ",
                     "window height",
-                    max_value=MAX_DIMENSION,
+                    min_value=MIN_WINDOW_HEIGHT,
+                    max_value=MAX_WINDOW_HEIGHT,
                     input_func=input_func,
                     output_func=output_func,
                 )
@@ -312,14 +370,16 @@ def get_openings(
                 width = read_positive_float(
                     "  Width (m): ",
                     "door width",
-                    max_value=MAX_DIMENSION,
+                    min_value=MIN_DOOR_WIDTH,
+                    max_value=MAX_DOOR_WIDTH,
                     input_func=input_func,
                     output_func=output_func,
                 )
                 height = read_positive_float(
                     "  Height (m): ",
                     "door height",
-                    max_value=MAX_DIMENSION,
+                    min_value=MIN_DOOR_HEIGHT,
+                    max_value=MAX_DOOR_HEIGHT,
                     input_func=input_func,
                     output_func=output_func,
                 )

--- a/roomsizer/cli.py
+++ b/roomsizer/cli.py
@@ -27,9 +27,9 @@ logger = logging.getLogger(__name__)
 # Sanity limits for dimensions (to catch typos)
 # Room dimensions
 MIN_ROOM_WIDTH = 1.5  # meters
-MAX_ROOM_WIDTH = 100.0  # meters
+MAX_ROOM_WIDTH = 25.0  # meters
 MIN_ROOM_LENGTH = 1.5  # meters
-MAX_ROOM_LENGTH = 100.0  # meters
+MAX_ROOM_LENGTH = 30.0  # meters
 MIN_ROOM_HEIGHT = 2.0  # meters
 MAX_ROOM_HEIGHT = 3.0  # meters
 
@@ -344,6 +344,15 @@ def get_openings(
                     output_func=output_func,
                 )
 
+                # Check if opening height exceeds room height
+                if height > room.height:
+                    output_func(
+                        f"  Warning: Window height ({height:.2f} m) exceeds room height ({room.height:.2f} m).",
+                        file=sys.stderr
+                    )
+                    output_func("  Please re-enter the window dimensions.", file=sys.stderr)
+                    continue
+
                 opening = Opening(width, height, OpeningKind.WINDOW)
                 room.add_opening(opening)
                 logger.info("[CLI] Added window %d: %.2f m × %.2f m", i + 1, width, height)
@@ -383,6 +392,15 @@ def get_openings(
                     input_func=input_func,
                     output_func=output_func,
                 )
+
+                # Check if opening height exceeds room height
+                if height > room.height:
+                    output_func(
+                        f"  Warning: Door height ({height:.2f} m) exceeds room height ({room.height:.2f} m).",
+                        file=sys.stderr
+                    )
+                    output_func("  Please re-enter the door dimensions.", file=sys.stderr)
+                    continue
 
                 opening = Opening(width, height, OpeningKind.DOOR)
                 room.add_opening(opening)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -745,3 +745,70 @@ class TestCLIIntegration:
         assert room_warning_line is not None
         # Max warning should NOT appear because room check prevents it
         assert max_warning_line is None
+
+    def test_cli_window_width_exceeds_room_width(self):
+        """Test Case 1: Window width cannot exceed room width (smallest wall).
+
+        Room is 5.5m × 10.0m. Window width of 5.6m should be rejected
+        because it exceeds the smallest wall dimension (5.5m).
+        """
+        responses = [
+            "5.5",      # room width
+            "10.0",     # room length
+            "2.0",      # room height
+            "1",        # number of windows
+            "5.6",      # window width - exceeds smallest wall (5.5m)
+            "5.0",      # window width - valid
+            "1.5",      # window height - valid
+            "0",        # number of doors
+            "0.53",     # roll width
+            "10.05",    # roll length
+            "n",        # no waste allowance
+        ]
+
+        mock_input = MockInput(responses)
+        output = io.StringIO()
+
+        from roomsizer.cli import run_interactive_mode
+
+        exit_code = run_interactive_mode(
+            input_func=mock_input,
+            output_func=lambda *args, **kwargs: output.write(str(args[0]) + "\n"),
+        )
+
+        output_text = output.getvalue()
+        assert exit_code == 0
+        assert "exceeds room width" in output_text
+
+    def test_cli_door_width_exceeds_room_width(self):
+        """Test Case 1: Door width cannot exceed room width (smallest wall).
+
+        Same validation should apply to doors as to windows.
+        """
+        responses = [
+            "5.5",      # room width
+            "10.0",     # room length
+            "2.5",      # room height
+            "0",        # number of windows
+            "1",        # number of doors
+            "5.6",      # door width - exceeds smallest wall (5.5m)
+            "0.9",      # door width - valid
+            "2.0",      # door height - valid
+            "0.53",     # roll width
+            "10.05",    # roll length
+            "n",        # no waste allowance
+        ]
+
+        mock_input = MockInput(responses)
+        output = io.StringIO()
+
+        from roomsizer.cli import run_interactive_mode
+
+        exit_code = run_interactive_mode(
+            input_func=mock_input,
+            output_func=lambda *args, **kwargs: output.write(str(args[0]) + "\n"),
+        )
+
+        output_text = output.getvalue()
+        assert exit_code == 0
+        assert "exceeds room width" in output_text


### PR DESCRIPTION
## Summary

Improve room and opening dimension validation in the CLI so that doors and windows always fit within the room, use consistent bounds, and provide clear, priority-based warnings for suspicious values.

## Changes

- Prevent windows/doors wider than the smallest wall
- Update window and door input validation
- Adjust dimension limits
  - Room:
    - Width: 1.5–25.0 m
    - Length: 1.5–30.0 m
    - Height: 2.0–3.0 m
  - Windows:
    - Width: 0.3–5.0 m
    - Height: 0.3–3.0 m
  - Doors:
    - Width: 0.6–3.0 m
    - Height: 1.8–3.0 m
  - Show warnings for values outside expected ranges and allow confirmation by re-entering the same value

## Tests

- Extended CLI tests for room and opening dimension validation
- Covered width/height checks against room dimensions
- Verified confirmation logic for out-of-bounds values
- All existing tests updated where needed and passing